### PR TITLE
Make validation thread safe using sync.Map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
- - 1.7.x
  - tip
 
 script:

--- a/validation.go
+++ b/validation.go
@@ -57,9 +57,9 @@ func (v *Validation) Validate(value interface{}, obj reflect.Value) *ValidationE
 	}
 }
 
-// DefaultValidationMap is the default validation
+// DefaultMap is the default validation
 // map used to tell if a struct is valid.
-var DefaultValidationMap = Map{}
+var DefaultMap = Map{}
 
 // Map is an atomic validation map
 // when two Set happen at the same time,
@@ -85,7 +85,7 @@ func (vm *Map) set(k reflect.Type, v []Interface) {
 // last one will become the validation for that key
 // using DefaultValidationMap.
 func AddValidation(key string, fn func(string, reflect.Kind) (Interface, error)) {
-	DefaultValidationMap.AddValidation(key, fn)
+	DefaultMap.AddValidation(key, fn)
 }
 
 // AddValidation registers the validation specified by key to the known
@@ -98,7 +98,7 @@ func (vm *Map) AddValidation(key string, fn func(string, reflect.Kind) (Interfac
 // IsValid determines if an object is valid based on its validation tags
 // using DefaultValidationMap.
 func IsValid(object interface{}) (bool, []ValidationError) {
-	return DefaultValidationMap.IsValid(object)
+	return DefaultMap.IsValid(object)
 }
 
 // IsValid determines if an object is valid based on its validation tags.

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,0 +1,33 @@
+package validation
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestValidationMap_Atomicity(t *testing.T) {
+	vm := ValidationMap{}
+	typ := reflect.TypeOf(vm)
+	wg1 := sync.WaitGroup{}
+	wg1.Add(1)
+	wg2 := sync.WaitGroup{}
+	wg2.Add(2)
+	count := 10000
+	go func() {
+		wg1.Wait()
+		for i := 0; i < count; i++ {
+			vm.Set(typ, nil)
+		}
+		wg2.Done()
+	}()
+	go func() {
+		wg1.Wait()
+		for i := 0; i < count; i++ {
+			vm.Get(typ)
+		}
+		wg2.Done()
+	}()
+	wg1.Done() // start !
+	wg2.Wait()
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestValidationMap_Atomicity(t *testing.T) {
-	vm := ValidationMap{}
+	vm := Map{}
 	typ := reflect.TypeOf(vm)
 	wg1 := sync.WaitGroup{}
 	wg1.Add(1)
@@ -17,14 +17,14 @@ func TestValidationMap_Atomicity(t *testing.T) {
 	go func() {
 		wg1.Wait()
 		for i := 0; i < count; i++ {
-			vm.Set(typ, nil)
+			vm.set(typ, nil)
 		}
 		wg2.Done()
 	}()
 	go func() {
 		wg1.Wait()
 		for i := 0; i < count; i++ {
-			vm.Get(typ)
+			vm.get(typ)
 		}
 		wg2.Done()
 	}()


### PR DESCRIPTION
Hi there,

This is to remove some concurrent access panics I've seen.